### PR TITLE
Modify execute to not decrement sim. time during halt

### DIFF
--- a/api.c
+++ b/api.c
@@ -384,19 +384,17 @@ conf_object_t * QEMU_get_object_by_name(const char *name) {
     return NULL;
 }
 
-int QEMU_cpu_execute (conf_object_t *cpu) {
+int QEMU_cpu_execute (conf_object_t *cpu, bool count_time) {
   
    assert(cpu->type == QEMU_CPUState);
 
   int ret = 0;
   CPUState * cpu_state = cpu->object;
   pending_exception = cpu_state->exception_index;
-  advance_qemu(cpu->object);
-  simulationTime--;
-
-  //ret = cpu_state->exception_index;
-  //ret =  get_info(cpu_state);
-
+  ret = advance_qemu(cpu->object);
+  if (count_time) {
+      simulationTime--;
+  }
   return ret;
 }
 

--- a/api.h
+++ b/api.h
@@ -591,7 +591,7 @@ typedef int                 (*QEMU_GET_NUM_THREADS_PER_CORE_PROC)(void);
 typedef int                 (*QEMU_CPU_GET_SOCKET_ID_PROC)      (conf_object_t *cpu);
 typedef conf_object_t*      (*QEMU_GET_ALL_CPUS_PROC)           (void);
 //typedef int                 (*CPU_PROC_NUM_PROC)                (void* cs);
-typedef int                 (*QEMU_CPU_EXEC_PROC)               (conf_object_t *cpu);
+typedef int                 (*QEMU_CPU_EXEC_PROC)               (conf_object_t *cpu, bool count_time);
 
 //qemu settings
 typedef void                (*QEMU_CPU_SET_QUANTUM)             (const int *val);
@@ -714,7 +714,7 @@ int QEMU_mem_op_is_read                                     (generic_transaction
 instruction_error_t QEMU_instruction_handle_interrupt       (conf_object_t *cpu, pseudo_exceptions_t pendingInterrupt);
 int QEMU_get_pending_exception                              (void);
 conf_object_t *QEMU_get_object_by_name                      (const char *name);
-int QEMU_cpu_execute                                        (conf_object_t *cpu);
+int QEMU_cpu_execute                                        (conf_object_t *cpu, bool count_time);
 int QEMU_is_in_simulation                                   (void);
 void QEMU_toggle_simulation                                 (int enable);
 void  QEMU_cpu_executeation                                 (int enable);


### PR DESCRIPTION
Modify QEMU_cpu_execute to optionally decrement simulation time. This is useful when CPUs are halted and the # of simulated instructions should not increment