### PR TITLE
fix: Unprivileged Load + Empty Zero Frequency

### DIFF
--- a/libqflex/libqflex-module.c
+++ b/libqflex/libqflex-module.c
@@ -79,7 +79,7 @@ struct libqflex_state_t qemu_libqflex_state = {
         .log_delay           = 0,
      },
 
-    .freq                       = "1:1", // 1GHz on core, 1Ghz un-core
+    .freq                       = "", // 1GHz on core, 1Ghz un-core
 
     .debug_lvl                  = "vverb",
     .mode                       = MODE_TIMING,

--- a/libqflex/libqflex-module.c
+++ b/libqflex/libqflex-module.c
@@ -170,6 +170,17 @@ libqflex_init(void)
     qemu_libqflex_state.n_vcpus = current_machine->smp.cpus;
     libqflex_populate_vcpus(qemu_libqflex_state.n_vcpus);
 
+    if (!*qemu_libqflex_state.freq) {
+        char *str = (char *)malloc((2*qemu_libqflex_state.n_vcpus+2) * sizeof(char));
+        str[0] = '\0';
+        for (int i = 0; i < qemu_libqflex_state.n_vcpus; i++)
+            strcat(str, "1:");
+        strcat(str, "1");
+        qemu_libqflex_state.freq = strdup(str);
+        qemu_log("> [Libqflex] Using default FREQ =%s\n", qemu_libqflex_state.freq);
+    } else 
+        qemu_log("> [Libqflex] Using FREQ         =%s\n", qemu_libqflex_state.freq);
+    
     ret = libqflex_flexus_init();
     if (!ret) exit(EXIT_FAILURE);
 

--- a/libqflex/libqflex.c
+++ b/libqflex/libqflex.c
@@ -260,6 +260,8 @@ libqflex_translate_va2pa(size_t cpu_index, logical_address_t va, bool unprivileg
     ARMMMUIdx mmu_idx = arm_mmu_idx(cpu_wrapper->env);
     if (unprivileged) {
         switch (mmu_idx) {
+            case ARMMMUIdx_E10_0:
+                break;
             case ARMMMUIdx_E10_1:
             case ARMMMUIdx_E10_1_PAN:
                 mmu_idx = ARMMMUIdx_E10_0;
@@ -268,8 +270,11 @@ libqflex_translate_va2pa(size_t cpu_index, logical_address_t va, bool unprivileg
             case ARMMMUIdx_E20_2_PAN:
                 mmu_idx = ARMMMUIdx_E20_0;
                 break;
-            default:
+            default: {
+                // Output the input MMU index.
+                qemu_log("ERROR: Unpexted MMU index for unprivileged translation: %d\n", mmu_idx);
                 g_assert_not_reached();
+            }
         }
     }
 

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,5 @@ system_ss.add(when: middleware_dep['snapvm-external'], if_true: files(
     'snapvm-external/snapvm-external-module.c',
     'snapvm-external/savevm-external.c',
     'snapvm-external/loadvm-external.c',
-    'snapvm-external/snapvm-qmp-cmds.c',
     'snapvm-external/snapvm-hmp-cmds.c',
 ))

--- a/snapvm-external/snapvm-qmp-cmds.c
+++ b/snapvm-external/snapvm-qmp-cmds.c
@@ -1,9 +1,0 @@
-#include "qemu/osdep.h"
-
-#include "middleware/trace.h"
-#include "qapi/qapi-commands-middleware.h"
-#include "qemu/error-report.h"
-
-void qmp_savevm_external(Error **errp) { printf("Hello, world!\n"); }
-
-void qmp_loadvm_external(Error **errp) { printf("Hello, world!\n"); }


### PR DESCRIPTION
This PR fixes two problems:
1. If an unprivileged load appears in the user space, it should use the unprivileged MMU index. This can be true when there is a speculation from the kernel to the userspace. 
2. The default value of freq is set to empty so that Flexus side can handle and give the default frequency. 